### PR TITLE
Removes unnecessary (and incorrect) line when loadFromPersistentStorage

### DIFF
--- a/DayX/EntryController.m
+++ b/DayX/EntryController.m
@@ -71,7 +71,6 @@ static NSString * const AllEntriesKey = @"allEntries";
 
 - (void)loadFromPersistentStorage {
     NSArray *entryDictionaries = [[NSUserDefaults standardUserDefaults] objectForKey:AllEntriesKey];
-    self.entries = entryDictionaries;
     
     NSMutableArray *entries = [NSMutableArray new];
     for (NSDictionary *entry in entryDictionaries) {


### PR DESCRIPTION
We were pulling out our array of entryDictionaries and setting that array to the EntryController's property entries (which is supposed to be an array of Entries, not an array of entryDictionaries)
